### PR TITLE
disable libcurl verbose output to stderr

### DIFF
--- a/src/Http/CurlRequest.php
+++ b/src/Http/CurlRequest.php
@@ -44,7 +44,7 @@ class CurlRequest implements HttpRequest
         curl_setopt($curl, CURLOPT_USERAGENT, $this->useragent);
         curl_setopt($curl, CURLOPT_POST, 1);
         curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($params));
-        curl_setopt($curl, CURLOPT_VERBOSE, true);
+        curl_setopt($curl, CURLOPT_VERBOSE, false);
         // empty string means send all supported encoding types
         curl_setopt($curl, CURLOPT_ENCODING, '');
         $result = curl_exec($curl);


### PR DESCRIPTION
Currently this library under certain circumstances throws a lot of output to STDERR because it sets `CURLOPT_VERBOSE=true`. e.g. on logins as shown below.

Could we default disable that - or make it otherwise configurable?
What do you think?

```
*   Trying 52.58.150.155...
* TCP_NODELAY set
* Connected to api-de.cronofy.com (52.58.150.155) port 443 (#0)
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=*.cronofy.com; O=Cronofy Limited; L=Nottingham; C=GB
*  start date: Nov 18 09:25:37 2019 GMT
*  expire date: Dec 24 15:25:37 2020 GMT
*  subjectAltName: host "api-de.cronofy.com" matched cert's "*.cronofy.com"
*  issuer: C=US; ST=Illinois; L=Chicago; O=Trustwave Holdings, Inc.; CN=Trustwave Organization Validation SHA256 CA, Level 1; emailAddress=ca@trustwave.com
*  SSL certificate verify ok.
> POST /oauth/token HTTP/1.1
Host: api-de.cronofy.com
User-Agent: Cronofy PHP 0.15.0
Accept: */*
Accept-Encoding: deflate, gzip
...
```

